### PR TITLE
add endorsed jars to prevent osgi errors

### DIFF
--- a/files/usr/local/share/nexus/bin/nexus.vmoptions
+++ b/files/usr/local/share/nexus/bin/nexus.vmoptions
@@ -20,6 +20,7 @@
 -XX:+LogVMOutput
 -XX:LogFile=/var/lib/nexus/sonatype-work/nexus3/log/jvm.log
 -XX:-OmitStackTraceInFastThrow
+-Djava.endorsed.dirs=lib/endorsed
 -Djava.net.preferIPv4Stack=true
 -Dkaraf.home=.
 -Dkaraf.base=.


### PR DESCRIPTION
this prevents the osgi error which appears harmless but blows up our logs on startup making deciphering actual errors difficult.